### PR TITLE
Add set_timeout functionality

### DIFF
--- a/doc/user_guide.rst
+++ b/doc/user_guide.rst
@@ -58,7 +58,19 @@ A very common scenario is to wait until a pact is finished. This is what the :fu
 		>>> p.is_finished()
 		True
 
-You can also specify a timeout in seconds. Expiration of the timeout will result in an exception:
+You can also set the default timeout for the pact. This is done by using :func:`pact.Pact.set_default_timeout` method:
+
+.. code-block:: python
+
+		>>> p = pact_delete_async('/path')
+		>>> p.set_default_timeout(timeout_seconds=5)
+		>>> try:
+		...     p.wait()
+		... except TimeoutExpired as e:
+		...     print('Got exception:', e)
+		Got exception: Timeout of 5 seconds expired waiting for <Pact: Deleting /path>
+
+Another option is to specify a timeout in seconds, which will override the default. Expiration of the timeout will result in an exception:
 
 .. code-block:: python
 

--- a/pact/base.py
+++ b/pact/base.py
@@ -20,6 +20,7 @@ class PactBase(object):
         self._then = []
         self._during = []
         self._timeout_callbacks = []
+        self.timeout_seconds = None
         _logger.debug("{0!r} was created", self)
 
     def _validate_can_add_callback(self):
@@ -96,15 +97,21 @@ class PactBase(object):
         self._timeout_callbacks.append(functools.partial(callback, *args, **kwargs))
         return self
 
+    def set_timeout(self, timeout_seconds):
+        self.timeout_seconds = timeout_seconds
+
     def _is_finished(self):
         raise NotImplementedError()  # pragma: no cover
 
-    def wait(self, **kwargs):
+    def wait(self, timeout_seconds=None, **kwargs):
         """Waits for this pact to finish
         """
+        if timeout_seconds is None:
+            timeout_seconds = self.timeout_seconds
+
         _logger.debug("Waiting for {0!r}", self)
         try:
-            waiting.wait(self.poll, waiting_for=self, **kwargs)
+            waiting.wait(self.poll, waiting_for=self, timeout_seconds=timeout_seconds, **kwargs)
             _logger.debug("Finish waiting for {0!r}", self)
         except TimeoutExpired:
             exc_info = sys.exc_info()

--- a/pact/base.py
+++ b/pact/base.py
@@ -20,7 +20,7 @@ class PactBase(object):
         self._then = []
         self._during = []
         self._timeout_callbacks = []
-        self.timeout_seconds = None
+        self._timeout_seconds = None
         _logger.debug("{0!r} was created", self)
 
     def _validate_can_add_callback(self):
@@ -97,17 +97,22 @@ class PactBase(object):
         self._timeout_callbacks.append(functools.partial(callback, *args, **kwargs))
         return self
 
-    def set_timeout(self, timeout_seconds):
-        self.timeout_seconds = timeout_seconds
+    def set_default_timeout(self, timeout_seconds):
+        """ Sets the default timeout for the pact. It will be used when pact.wait() is called.
+        """
+        self._timeout_seconds = timeout_seconds
 
     def _is_finished(self):
         raise NotImplementedError()  # pragma: no cover
 
     def wait(self, timeout_seconds=None, **kwargs):
         """Waits for this pact to finish
+        If timeout_seconds is set, it will be used as the timeout.
+        Otherwise the last value set by set_default_timeout will be used.
+        If not set at all, the wait will be executed with timeout_seconds=None and will have infinite wait.
         """
         if timeout_seconds is None:
-            timeout_seconds = self.timeout_seconds
+            timeout_seconds = self._timeout_seconds
 
         _logger.debug("Waiting for {0!r}", self)
         try:

--- a/tests/test_pact.py
+++ b/tests/test_pact.py
@@ -78,6 +78,12 @@ def test_on_timeout(pact, callback, forge):
         pact.wait(timeout_seconds=3)
 
 
+def test_set_timeout(pact):
+    pact.set_timeout(1)
+    with pytest.raises(TimeoutExpired):
+        pact.wait()
+
+
 class SampleException(Exception):
     pass
 

--- a/tests/test_pact.py
+++ b/tests/test_pact.py
@@ -78,8 +78,8 @@ def test_on_timeout(pact, callback, forge):
         pact.wait(timeout_seconds=3)
 
 
-def test_set_timeout(pact):
-    pact.set_timeout(1)
+def test_set_default_timeout(pact):
+    pact.set_default_timeout(1)
     with pytest.raises(TimeoutExpired):
         pact.wait()
 


### PR DESCRIPTION
It allows pact creator to set the pact's timeout, and the caller only
needs to call pact.wait() without timeout considerations.