### PR TITLE
Handle exceptions thrown in a 'during' callback

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,6 +1,7 @@
 Changelog
 =========
 
+* :bug:`- major` Handle exceptions thrown in a 'during' callback
 * :release:`1.8.0 <11-07-2017>`
 * :feature:`-` Add lastly callbacks that are similar to 'then' but called afterwards
 * :release:`1.7.0 <27-06-2017>`

--- a/pact/base.py
+++ b/pact/base.py
@@ -44,27 +44,31 @@ class PactBase(object):
         if self._finished:
             return True
 
-        for callback in self._during:
-            callback()
+        exc_info = self._process_callbacks('during')
 
         self._finished = self._is_finished()
-        exc_info = None
 
         if self._finished and not self._triggered:
             self._triggered = True
-            for callback in itertools.chain(self._then, self._lastly):
-                try:
-                    callback()
-                except Exception: # pylint: disable=broad-except
-                    if exc_info is None:
-                        exc_info = sys.exc_info()
-                    _logger.debug("Exception thrown from 'then/lastly' callback {!r} of {!r}",
-                                  callback, self, exc_info=True)
+            then_exc_info = self._process_callbacks('then')
+            lastly_exc_info = self._process_callbacks('lastly')
+            exc_info = exc_info or then_exc_info or lastly_exc_info
+
         if exc_info is not None:
             reraise(*exc_info)
 
         return self.is_finished()
 
+    def _process_callbacks(self, name):
+        exc_info = None
+        for callback in getattr(self, '_{}'.format(name)):
+            try:
+                callback()
+            except Exception: # pylint: disable=broad-except
+                if exc_info is None:
+                    exc_info = sys.exc_info()
+                _logger.debug("Exception thrown from '{}' callback {!r} of {!r}", name, callback, self, exc_info=True)
+        return exc_info
 
     @deprecated('Use poll() and/or is_finished() instead')
     def finished(self):

--- a/tests/test_pact.py
+++ b/tests/test_pact.py
@@ -49,6 +49,29 @@ def test_add_not_callable_to_pact_fails(pact, pact_callback):
         pact_callback(True)
 
 
+def test_during_exception(pact, state, forge, callback):
+    callback(1)
+    callback(2).and_raise(SampleException())
+    callback(3)
+    callback(4)
+    callback(5)
+
+    forge.replay()
+
+    pact.during(callback, 1)
+    pact.during(callback, 2)
+    pact.during(callback, 3)
+    pact.then(callback, 4)
+    pact.lastly(callback, 5)
+
+    state.finish()
+    with pytest.raises(SampleException):
+        pact.poll()
+
+    forge.verify()
+    assert pact.is_finished()
+
+
 def test_then_exception(pact, state, forge, callback):
     callback(1)
     callback(2).and_raise(SampleException())


### PR DESCRIPTION
During callbacks might throw exceptions but that should not prevent the pact from finishing.